### PR TITLE
fix(profile): remove unreachable duplicate null check in findUser

### DIFF
--- a/src/profile/profile.service.ts
+++ b/src/profile/profile.service.ts
@@ -41,8 +41,6 @@ export class ProfileService {
       );
     }
 
-    if (!profile) return null;
-
     return {
       ...profile,
       isFollowing,


### PR DESCRIPTION
## Summary
- Removes the duplicate `if (!profile) return null` check at line 44 in `profile.service.ts`
- The first null guard at line 33 already handles this case — the second check was unreachable dead code
- Likely left behind from an incomplete refactor

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint:check`)
- [x] Prisma schema validates (`npm run prisma:validate`)
- [ ] E2E tests require a running Postgres + Redis (not available in this environment — should pass in CI with Docker)

https://claude.ai/code/session_01ParaXmDbSnSkRASJPv8KVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01ParaXmDbSnSkRASJPv8KVY)_